### PR TITLE
Fix entity hard collision issue.

### DIFF
--- a/patches/server/0037-Collision-cache.patch
+++ b/patches/server/0037-Collision-cache.patch
@@ -389,18 +389,23 @@ index 0000000000000000000000000000000000000000..017da9e1461250a0fd8baacdcca203d6
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/util/CollisionUtil.java b/src/main/java/io/papermc/paper/util/CollisionUtil.java
-index 98ca1199a823cdf55b913396ce0a24554e85f116..840142d340d4569772552b961f829ca921b15dc4 100644
+index 98ca1199a823cdf55b913396ce0a24554e85f116..b16e65fa8be40f6c938c8c183c9bca7c13acc9e2 100644
 --- a/src/main/java/io/papermc/paper/util/CollisionUtil.java
 +++ b/src/main/java/io/papermc/paper/util/CollisionUtil.java
-@@ -547,6 +547,13 @@ public final class CollisionUtil {
+@@ -547,6 +547,18 @@ public final class CollisionUtil {
          return ret;
      }
  
 +    public static boolean getEntityCollisionsWithCache(final net.minecraft.world.level.Level getter, Entity entity, AABB aabb, List<AABB> into,
 +                                                       final boolean loadChunks, final boolean collidesWithUnloaded,
 +                                                       final boolean checkBorder, final boolean checkOnly, final BiPredicate<BlockState, BlockPos> predicate) {
-+        return entity.collisionCache.getCollisions(getter, aabb, into, collidesWithUnloaded, checkOnly, predicate) ||
-+                getEntityHardCollisions(getter, entity, aabb, into, checkOnly, null);
++        if (checkOnly) {
++            return entity.collisionCache.getCollisions(getter, aabb, into, collidesWithUnloaded, checkOnly, predicate) ||
++                    getEntityHardCollisions(getter, entity, aabb, into, checkOnly, null);
++        } else {
++            return entity.collisionCache.getCollisions(getter, aabb, into, collidesWithUnloaded, checkOnly, predicate) |
++                    getEntityHardCollisions(getter, entity, aabb, into, checkOnly, null);
++        }
 +    }
 +
      public static boolean getEntityHardCollisions(final CollisionGetter getter, final Entity entity, AABB aabb,
@@ -485,7 +490,7 @@ index ff0fab668801d0b32abffbfedc7eb24abf71fed0..db7904b1bb402a36684b97c443336630
              return null;
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 1ed6573e0ca6b353d1de3b4486e199a5db9aa447..125a067ac989ba05e796c1aa5c28206dbe08eb50 100644
+index 9681e397588a8abc4150b991e546fa79b5635c87..646385d0bef31f43a7273fa78ec696dfc761093c 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -606,6 +606,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A


### PR DESCRIPTION
The introduction of the collision cache breaks some Wither farms which rely on the hard collisions of boats to cage the Wither.
This PR resolves that by removing the short-circuit in the call to `getEntityHardCollisions`.

The performance implications of this PR have not been tested.