### PR TITLE
Update gradle.properties due to missing depend upstream

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version = 1.17.1-R0.1-SNAPSHOT
 
 mcVersion = 1.17.1
 packageVersion = 1_17_1_R1
-paperRef = c53577e3c0ed48a3e5c728c9e8fac96312b1c6f1
+paperRef = 6625db387ea9fe5296a6c6f984975b387c3089f0
 
 org.gradle.jvmargs=-Xmx2G
 


### PR DESCRIPTION
Quilt removed yarn from its maven repo. This is needed for paper to generate mappings. Paper updated to pull from Fabric's repo instead here: https://github.com/PaperMC/Paper/commit/2c0515f6aac864af51d9839399698d61d5d00dd8

Figured might as well update to latest 1.17 commit as they made a couple more changes after that. 